### PR TITLE
ci: remove retired windows-2019 runner from CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
       - test
     strategy:
       matrix:
-        os: [ 'windows-2022', 'windows-2019' ]
+        os: [ 'windows-2022' ]
         sqlserver: [ 'sql-latest', 'sql-2022', 'sql-2019', 'sql-2017', 'sql-2016', 'sql-2014', 'sql-2012', 'sql-2008' ]
         # These sqlserver versions don't work on windows-2022 (at the moment)
         exclude:


### PR DESCRIPTION
> [!WARNING]
> Windows Server 2019 has been retired. The Windows Server 2019 image has been removed as of 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045