### PR TITLE
ci: include built files in release commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint:fix": "npm run lint -- --fix",
     "prepare": "npm run build",
     "test": "mocha -r ts-node/register './test/**/**.ts'",
-    "test:coverage": "nyc --all npm run test --silent"
+    "test:coverage": "nyc --all npm run test --silent",
+    "version": "npm run build && git add README.md lib/"
   },
   "files": [
     "action.yml",


### PR DESCRIPTION
## Problem

When semantic-release creates a new release, `@semantic-release/npm` bumps the version in `package.json`, but the project is not rebuilt before the release commit is created. This means `README.md` (which derives the usage version tag from `package.json`) and `lib/main/index.js` are stale in the release commit, causing the `Check built files` CI job to fail on subsequent pushes to master.

## Fix

Add a `version` script to `package.json` that runs `npm run build && git add README.md lib/`. This hooks into the npm version lifecycle that `@semantic-release/npm` triggers when bumping the version, ensuring the built output is rebuilt and staged before the release commit.