### PR TITLE
ci: use .nvmrc for Node.js version in CI workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 20.x
+          node-version-file: '.nvmrc'
           cache: 'npm'
       - name: Install dependencies
         run: npm clean-install
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 20.x
+          node-version-file: '.nvmrc'
           cache: 'npm'
       - name: Install dependencies
         run: npm clean-install
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 20.x
+          node-version-file: '.nvmrc'
           cache: 'npm'
       - name: Install dependencies
         run: npm clean-install
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 20.x
+          node-version-file: '.nvmrc'
           cache: 'npm'
       - name: Install dependencies
         run: npm clean-install
@@ -106,7 +106,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 20.x
+          node-version-file: '.nvmrc'
           cache: 'npm'
       - name: Install deps
         run: npm ci
@@ -164,7 +164,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: "lts/*"
+          node-version-file: '.nvmrc'
           cache: 'npm'
       - name: Install dependencies
         run: npm clean-install


### PR DESCRIPTION
## Problem

CI jobs use a mix of hardcoded Node.js versions (`20.x` in most jobs, `lts/*` in the release job), while the repository has a `.nvmrc` pinning Node 24. This means CI runs on a different Node version than local development and the action runtime.

## Fix

Replace all `node-version` values with `node-version-file: '.nvmrc'` so every CI job uses the version pinned in the repository. Updating Node for CI now only requires changing `.nvmrc`.
