### PR TITLE
chore(deps-dev): upgrade typescript to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,8 +43,8 @@
         "nyc": "^18.0.0",
         "sinon": "^21.0.0",
         "sinon-chai": "^3.7.0",
-        "ts-node": "^10.9.1",
-        "typescript": "^5.9.2",
+        "ts-node": "^10.9.2",
+        "typescript": "^6.0.2",
         "typescript-eslint": "^8.58.2"
       }
     },
@@ -11635,9 +11635,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "nyc": "^18.0.0",
     "sinon": "^21.0.0",
     "sinon-chai": "^3.7.0",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.9.2",
+    "ts-node": "^10.9.2",
+    "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.2"
   },
   "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     "sourceMap": true,
     "noImplicitAny": false,                   /* Raise error on expressions and declarations with an implied 'any' type. */
-    "resolveJsonModule": true                /* Allows importing modules with a '.json' extension, which is a common practice in node projects. */
+    "resolveJsonModule": true,               /* Allows importing modules with a '.json' extension, which is a common practice in node projects. */
+    "types": ["node", "mocha"]
   },
   "exclude": ["test", "lib", "node_modules", "misc"]
 }


### PR DESCRIPTION
Closes #191 (supersedes the dependabot TS 5.9.3 bump).

## Changes

- Upgrade TypeScript from `^5.9.2` to `^6.0.2`
- Add explicit `types: ["node", "mocha"]` to `tsconfig.json` — TS 6 no longer auto-includes `@types/*` packages
- Bump `ts-node` range to `^10.9.2`

All tests, lint, and build pass locally.